### PR TITLE
Big integers

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.0] - 2018-06-15
+### Added
+- json-bigint for json response body parsing in case that there are big integers which JSON cannot handle itself
+- Added the possebility to pass the `maxredirects=0` header to custom requests in order to suppress redirects only for certain requests
+### Changed
+- Fixed: Array headers in template are now correct formatted
+### Removed
 
 ## [1.4.5] - 2018-06-11
 ### Added
@@ -48,7 +55,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 
-[Unreleased]: https://github.com/mbaertschi/node-vcr/compare/v1.4.5...HEAD
+[Unreleased]: https://github.com/mbaertschi/node-vcr/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/mbaertschi/node-vcr/compare/v1.4.5...v2.0.0
 [1.4.5]: https://github.com/mbaertschi/node-vcr/compare/v1.4.4...v1.4.5
 [1.4.4]: https://github.com/mbaertschi/node-vcr/compare/v1.4.3...v1.4.4
 [1.4.3]: https://github.com/mbaertschi/node-vcr/compare/v1.4.2...v1.4.3

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "follow-redirects": "^1.5.0",
     "fs-extra": "^6.0.1",
     "incoming-message-hash": "^3.2.2",
+    "json-bigint": "^0.3.0",
     "pretty-data": "^0.40.0"
   },
   "jest": {
@@ -74,6 +75,7 @@
     "collectCoverage": true,
     "coverageDirectory": "reports/coverage",
     "reporters": [
+      "default",
       "jest-junit"
     ],
     "setupTestFrameworkScriptFile": "<rootDir>/test/global.config.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-vcr",
-  "version": "1.4.5",
+  "version": "2.0.0",
   "description": "Record your test suite's HTTP interactions and replay them during future test runs for fast, deterministic, accurate tests",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -25,7 +25,15 @@ const proxy = (req, body, host, maxRedirects, callback) => {
 
   const uri = url.parse(host)
   const protocol = uri.protocol.replace(':', '')
-  const mod = maxRedirects ? (followRedirects[protocol] || followRedirects.http) : (modMapping[protocol] || http)
+
+  // if maxRedirects is enabled in settings the client still can disable
+  // redirect for custom request by setting the maxredirects header to 0
+  let redirect = maxRedirects > 0
+  if (req.headers.maxredirects === '0') {
+    redirect = false
+  }
+
+  const mod = redirect ? followRedirects[protocol] || followRedirects.http : modMapping[protocol] || http
   const pReq = mod.request({
     hostname: uri.hostname,
     port: uri.port,

--- a/src/record.js
+++ b/src/record.js
@@ -1,6 +1,7 @@
 const pd = require('pretty-data').pd
 const fse = require('fs-extra')
 const zlib = require('zlib')
+const JSONBigInt = require('json-bigint')
 const buffer = require('./buffer')
 const { getContentType, isHumanReadable, isCompressed } = require('./media-type')
 const { render } = require('./template')
@@ -40,10 +41,14 @@ const record = (req, res, filename, ignoredHeaders, reqBody) => {
       body = Buffer.concat(body).toString(encoding)
       let data = body
       try {
-        if (pd[contentType]) {
-          data = pd[contentType](body)
-          if (reqBody) {
-            reqBody = pd[contentType](reqBody)
+        if (contentType === 'json') {
+          data = JSON.stringify(JSONBigInt.parse(data), null, 2)
+        } else {
+          if (pd[contentType]) {
+            data = pd[contentType](body)
+            if (reqBody) {
+              reqBody = pd[contentType](reqBody)
+            }
           }
         }
       } catch (error) {

--- a/src/template.js
+++ b/src/template.js
@@ -1,8 +1,12 @@
+const _ = require('lodash')
+
 const sanitizeHeader = (header) => {
   if (Array.isArray(header)) {
     header = header.map((value) => {
       return value.replace(/'/g, '\\\'')
     })
+  } else if (typeof header === 'object') {
+    header = _.mapValues(header, sanitizeHeader)
   } else if (typeof header === 'string') {
     header = header.replace(/'/g, '\\\'')
   }
@@ -51,9 +55,15 @@ module.exports = function (req, res) {
   Object.keys(res.headers)
     .filter((key) => ignoredHeaders.indexOf(key) === -1)
     .forEach((key) => {
-      template +=
+      if (Array.isArray(res.headers[key])) {
+        template +=
+`
+  res.setHeader('${key}', ['${sanitizeHeader(res.headers[key]).join('\', \'')}'])`
+      } else {
+        template +=
 `
   res.setHeader('${key}', '${sanitizeHeader(res.headers[key])}')`
+      }
     })
 
   template +=

--- a/yarn.lock
+++ b/yarn.lock
@@ -795,6 +795,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bignumber.js@^7.0.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
+
 binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
@@ -3141,6 +3145,12 @@ jsesc@^1.3.0:
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
+
+json-bigint@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-0.3.0.tgz#0ccd912c4b8270d05f056fbd13814b53d3825b1e"
+  dependencies:
+    bignumber.js "^7.0.0"
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"


### PR DESCRIPTION
Fixes
- Arrays in headers are now handled correctly in template rendering

## Proposed Changes

  - use [json-bigint](https://github.com/sidorares/json-bigint) to parse json body in response
  - users can now pass the `maxredirects=0` header to a custom request in order to suppress redirects for only certain requests
